### PR TITLE
Fix config backup path

### DIFF
--- a/Desktop/Config/ModuleConfig.cs
+++ b/Desktop/Config/ModuleConfig.cs
@@ -71,8 +71,8 @@ public class ModuleConfig<T> : IModuleConfig<T> where T : new()
                 {
                     _logger.LogCritical(e, "Error during deserialization/loading of config");
                     _logger.LogWarning("Attempting to move old config and generate a new one");
-                    var configName = Path.GetFileName(_configPath);
-                    File.Move(configName, $"{configName}.old");
+                    var backupPath = _configPath + ".old";
+                    File.Move(_configPath, backupPath);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- ensure old config backup uses the full path

## Testing
- `dotnet build Desktop/Desktop.csproj -c Release` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_688b4c951c948327aa025c025a3469e4