### PR TITLE
Fix tag selection regex

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -17,6 +17,11 @@ on:
         required: false
         type: boolean
         default: false
+      rc:
+        description: 'Tag image as rc'
+        required: false
+        type: boolean
+        default: false
   workflow_dispatch:
 
 name: ci-build
@@ -145,6 +150,7 @@ jobs:
           tags: |
             type=raw,value={{branch}},enable=${{ github.ref_type == 'branch' && github.event_name != 'pull_request' }}
             type=raw,value=latest,enable=${{ inputs.latest || false }}
+            type=raw,value=rc,enable=${{ inputs.rc || false }}
             type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
@@ -156,7 +162,7 @@ jobs:
         with:
           context: .
           file: Dockerfile
-          push: ${{ inputs.latest || (github.ref_protected && github.event_name != 'pull_request') }}
+          push: ${{ inputs.latest || inputs.rc || (github.ref_protected && github.event_name != 'pull_request') }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: ${{ inputs.platforms || 'linux/amd64' }}

--- a/.github/workflows/ci-tag.yml
+++ b/.github/workflows/ci-tag.yml
@@ -18,17 +18,37 @@ jobs:
       - name: Find latest tag
         id: latest-tag
         uses: oprypin/find-latest-tag@v1
+        continue-on-error: true
         with:
           repository: ${{ github.repository }}
-          regex: '^\d+\.\d+\.\d+(-[0-9A-Za-z]+(\.\d+)*)?$'
+          # Ignore preview or RC tags when searching for the latest
+          regex: '^\d+\.\d+\.\d+$'
           releases-only: false
       - name: Set output
         run: echo "latest-tag=${{ steps.latest-tag.outputs.tag }}"
 
+  # Pre-job to find the latest RC tag
+  get-latest-rc-tag:
+    runs-on: ubuntu-latest
+    outputs:
+      latest-rc: ${{ steps.latest-rc.outputs.tag }}
+    steps:
+      - name: Find latest RC tag
+        id: latest-rc
+        uses: oprypin/find-latest-tag@v1
+        continue-on-error: true
+        with:
+          repository: ${{ github.repository }}
+          regex: '^\d+\.\d+\.\d+-rc\.\d+$'
+          releases-only: false
+      - name: Set output
+        run: echo "latest-rc=${{ steps.latest-rc.outputs.tag }}"
+
   # Delegate building and containerizing to a single workflow.
   build:
-    needs: get-latest-tag
+    needs: [get-latest-tag, get-latest-rc-tag]
     uses: ./.github/workflows/ci-build.yml
     with:
       platforms: linux/amd64,linux/arm64
       latest: ${{ needs.get-latest-tag.outputs.latest-tag == github.ref_name }}
+      rc: ${{ needs.get-latest-rc-tag.outputs.latest-rc == github.ref_name }}


### PR DESCRIPTION
## Summary
- ignore prerelease tags when choosing the latest tag
- track the latest `x.x.x-rc.x` tag separately
- publish docker images tagged as `rc`
- handle missing tags gracefully

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b7548c49c83279655affb83bd3476