### PR TITLE
Fix updater file overwrite mode

### DIFF
--- a/Desktop/Services/Updater.cs
+++ b/Desktop/Services/Updater.cs
@@ -269,7 +269,11 @@ public sealed class Updater
 
         await using (var stream = await download.Content.ReadAsStreamAsync())
         {
-            await using var fStream = new FileStream(_setupFilePath, FileMode.OpenOrCreate);
+            await using var fStream = new FileStream(
+                _setupFilePath,
+                FileMode.Create,
+                FileAccess.Write,
+                FileShare.None);
             var relativeProgress = new Progress<long>(downloadedBytes =>
                 DownloadProgress.Value = ((double)downloadedBytes / totalBytes) * 100);
             


### PR DESCRIPTION
## Summary
- ensure the updater overwrites the downloaded installer using FileMode.Create with write access

## Testing
- dotnet publish Desktop/Desktop.csproj -c Release-Photino -o ./publish/Photino-Linux *(fails: dotnet is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68f752b83fd08327ab064b017f7665c6