### PR TITLE
Fix module removal task handling

### DIFF
--- a/Desktop/ModuleManager/ModuleManager.cs
+++ b/Desktop/ModuleManager/ModuleManager.cs
@@ -100,7 +100,7 @@ public sealed class ModuleManager : IAsyncDisposable
             {
                 _logger.LogInformation("Removing module {ModuleId}", moduleTask.Key);
                 RemoveModule(moduleTask.Key);
-                return Task.FromResult(Task.CompletedTask);
+                return Task.CompletedTask;
             });
     }
 


### PR DESCRIPTION
## Summary
- ensure module removal tasks return a completed Task rather than a nested Task instance

## Testing
- not run (dotnet SDK not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_68f794441f288327844ae0a8e2ee9ee7