### PR TITLE
Fix module injection to continue processing remaining properties

### DIFF
--- a/Desktop/OpenShockModuleComponentActivator.cs
+++ b/Desktop/OpenShockModuleComponentActivator.cs
@@ -55,7 +55,7 @@ public class OpenShockModuleComponentActivator : IComponentActivator
                 _logger.LogWarning(
                     "Property {PropertyName} on component {ComponentType} has already been set, skipping injection",
                     prop.Name, componentType.Name);
-                return;
+                continue;
             }
 
             var service = module.Module.ModuleServiceProvider.GetService(prop.PropertyType);


### PR DESCRIPTION
## Summary
- ensure module component activation skips already-set properties without aborting the rest of the injections

## Testing
- not run (dotnet SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68fa1fd236448327bbcc61ed18e99b58